### PR TITLE
ci: keep releases focused on packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,13 +163,6 @@ jobs:
             native/client/render-versioned-files.sh
           git diff --exit-code -- native/client/control native/client/Resources/Info.plist
 
-      - name: Test backend
-        working-directory: backend
-        run: |
-          test -z "$(gofmt -l .)"
-          go vet ./...
-          go test -race ./...
-
       - uses: actions/download-artifact@v4
         with:
           pattern: surf-*


### PR DESCRIPTION
Remove the backend format, vet, and race-test pass from the release job. Release now builds and verifies only the artifacts it publishes; backend validation stays local during development.